### PR TITLE
add command to make sure openlibrary database is used 

### DIFF
--- a/openlibrary-db.sql
+++ b/openlibrary-db.sql
@@ -3,6 +3,7 @@
 -- DROP DATABASE openlibrary;
 
 CREATE DATABASE openlibrary
+/c openlibrary
   WITH OWNER = postgres
        ENCODING = 'UTF8'
        TABLESPACE = pg_default


### PR DESCRIPTION
Hi,  thank you so much for creating this project. It has been immensely helpful for me.    
    I wanted to add /c openlibrary because when I ran the script originally  psql kept creating a postgres database and filling tables there instead of using openlibrary. 
  