### PR TITLE
Fix openlibrary-data-loader.sql query

### DIFF
--- a/db_scripts/openlibrary-data-loader.sql
+++ b/db_scripts/openlibrary-data-loader.sql
@@ -4,7 +4,7 @@
 -- spool the output into copy_commands.sql to generate all the copy commands
 \o copy_commands.sql
 select format('\copy %s from ''./data/processed/%s'' delimiter E''\t'' quote ''|'' csv;', name_of_table, filename)
-from (select id, name_of_table, filename from fileinfo, unnest(filenames) AS filename where hasBeenLoaded = false order by id limit 1) t;
+from (select id, name_of_table, filenames from fileinfo where hasBeenLoaded = false order by id limit 1) t, unnest(filenames) AS filename;
 
 -- turn spooling off
 \o


### PR DESCRIPTION
Fixes #12 

* `limit 1` in the inner query causes the script to only import the first file from the `filenames` list (using Postgres 15), since the limit is applied after unnesting the filenames.
* We can fix this by moving `unnest(filenames) AS filename` to the outer query, so that the limit is applied before unnesting the filenames.
